### PR TITLE
fixed config folder path on os x

### DIFF
--- a/starcheat/config.py
+++ b/starcheat/config.py
@@ -7,7 +7,7 @@ import configparser, os, platform
 if platform.system() == "Windows":
     config_folder = os.path.join(os.path.expandvars("%APPDATA%"), "starcheat")
 elif platform.system() == "Darwin":
-    config_folder = os.path.expanduser("~/Library/Application\ Support/starcheat")
+    config_folder = os.path.expanduser("~/Library/Application Support/starcheat")
 else:
     config_folder = os.path.expanduser("~/.starcheat")
 


### PR DESCRIPTION
sry, I reintroduced this bug while adding the elif platform.system() == "Darwin"

python already escapes whitespaces
