### PR TITLE
added -v and --version cmd line parameter [skip ci]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then brew install https://raw.github.com/wizzomafizzo/starcheat/master/mac/pyqt5.rb; fi
 script:
   - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then brew install -v https://raw.github.com/wizzomafizzo/starcheat/master/mac/starcheat.rb --with-dist; fi
+  - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then brew test -v https://raw.github.com/wizzomafizzo/starcheat/master/mac/starcheat.rb; fi
 branches:
   only:
     - master

--- a/mac/starcheat.rb
+++ b/mac/starcheat.rb
@@ -64,22 +64,25 @@ class Starcheat < Formula
       system "#{Formula.factory('qt5').bin}/macdeployqt", 'dist/starcheat.app', '-verbose=2'
       cp_r 'dist/starcheat.app', prefix/'StarCheat.app'
       rm_rf ['build', 'dist', 'setup.py']
-
-      cd prefix do
-        # Creates and uploades the archive
-        system 'tar', 'czf', 'starcheat.tar.gz', 'StarCheat.app'
-        # why using octokit when you habe curl and regex ;-) (creates a new release from the current commit and extracts the upload url from it)
-        `curl -H "Authorization: token #{HOMEBREW_GITHUB_API_TOKEN}" -H "Accept: application/json" -d '{"tag_name":"#{ENV['TRAVIS_COMMIT'][0..6]}","target_commitish":"#{ENV['TRAVIS_COMMIT']}","name":"starcheat (#{ENV['TRAVIS_COMMIT'][0..6]})","prerelease":true}' https://api.github.com/repos/wizzomafizzo/starcheat/releases` =~ /.*"upload_url":\s*"([\w\.\:\/]*){\?name}.*/m
-        `curl -H "Authorization: token #{HOMEBREW_GITHUB_API_TOKEN}" -H "Accept: application/json" -H "Content-Type: application/gzip" --data-binary @starcheat.tar.gz #{$1}?name=starcheat-#{ENV['TRAVIS_COMMIT'][0..6]}.tar.gz` unless $1.nil?
-        raise "Skipping uploading build because tag is already in use" if $1.nil?
-      end if build.with? 'dist'
-
     end if build.with? 'app'
 
     if build.with? 'binary'
       libexec.install Dir['build/*']
       bin.install_symlink libexec+'starcheat.py' => 'starcheat'
     end
+  end
+  
+  test do
+    system bin/'starcheat', '-v' if build.with? 'binary'
+    system prefix/'StarCheat.app/Contents/MacOS/starcheat', '-v' if build.with? 'app'
+    cd prefix do
+      # Creates and uploades the archive
+      system 'tar', 'czf', 'starcheat.tar.gz', 'StarCheat.app'
+      # why using octokit when you habe curl and regex ;-) (creates a new release from the current commit and extracts the upload url from it)
+      `curl -H "Authorization: token #{HOMEBREW_GITHUB_API_TOKEN}" -H "Accept: application/json" -d '{"tag_name":"#{ENV['TRAVIS_COMMIT'][0..6]}","target_commitish":"#{ENV['TRAVIS_COMMIT']}","name":"starcheat (#{ENV['TRAVIS_COMMIT'][0..6]})","prerelease":true}' https://api.github.com/repos/wizzomafizzo/starcheat/releases` =~ /.*"upload_url":\s*"([\w\.\:\/]*){\?name}.*/m
+      `curl -H "Authorization: token #{HOMEBREW_GITHUB_API_TOKEN}" -H "Accept: application/json" -H "Content-Type: application/gzip" --data-binary @starcheat.tar.gz #{$1}?name=starcheat-#{ENV['TRAVIS_COMMIT'][0..6]}.tar.gz` unless $1.nil?
+      raise "Skipping uploading build because tag is already in use" if $1.nil?
+    end if build.with? 'dist'
   end
 
   def caveats

--- a/starcheat/starcheat.py
+++ b/starcheat/starcheat.py
@@ -12,6 +12,10 @@ if not os.path.isdir(config.log_folder):
     os.mkdir(config.log_folder)
 
 def main():
+    if ("--version" in sys.argv or "-v" in sys.argv):
+        sys.stdout.write("starcheat alpha\n")
+        sys.exit(0)
+
     # TODO: set logging level in ini and cmd line
     # TODO: probably can save some file space omitting the date in timestamp
     logging.basicConfig(filename=log_file, level=logging.DEBUG,


### PR DESCRIPTION
this will add a simple command line option (`-v`or `--version`), which will print the current version to stdout and exit if 0. It can be used to determine if something went wrong building a static release (because if this case ther will be an error and an non-zero exit code). I changed the formula, so that travis will only upload the .app if `-v`return a 0 exit code.

Feel free to edit this while merging if you think another versionn number than alpha fits bether ;)
