### PR TITLE
travis: tagged releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ before_install:
 env:
   secure: "TRQYNASiBc+mf49oNxfL+DIADIgmOk41JGCZ0xFS0YdjMxF1FHz3mLJgjGCqxnaPZ7Xv2POg8zBdlRKPwnqueJT2QtK/PXI8I90/AkLmK2LAbxcAW4enyhNGqREW5ir+avMdq831iGHNsL25JhdIjyVTh3wD1fLybwKXkIav7lc="
 install:
-  - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then brew install python3 qt5; fi
-  - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then brew install https://raw.github.com/wizzomafizzo/starcheat/master/mac/pyqt5.rb; fi
+  - if [[ $TRAVIS_SECURE_ENV_VARS == 'false' ]]; then exit 42; fi
+  - brew install python3 --without-xz
+  - brew install qt5
+  - brew install https://raw.github.com/wizzomafizzo/starcheat/master/mac/pyqt5.rb
 script:
-  - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then brew install -v https://raw.github.com/wizzomafizzo/starcheat/master/mac/starcheat.rb --with-dist; fi
-  - if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then brew test -v https://raw.github.com/wizzomafizzo/starcheat/master/mac/starcheat.rb; fi
+  - brew install -v https://raw.github.com/wizzomafizzo/starcheat/master/mac/starcheat.rb
+  - brew test -v https://raw.github.com/wizzomafizzo/starcheat/master/mac/starcheat.rb --with-dist
 branches:
   only:
-    - master
+    - /^v?(\d)+(\.\d+)*/

--- a/mac/starcheat.rb
+++ b/mac/starcheat.rb
@@ -2,12 +2,10 @@ require 'formula'
 
 class Starcheat < Formula
   homepage 'https://github.com/wizzomafizzo/starcheat'
-  url 'https://github.com/wizzomafizzo/starcheat.git'
-  version 'beta'
+  url "https://github.com/wizzomafizzo/starcheat/archive/#{ENV['TRAVIS_BRANCH']}.tar.gz"
 
   depends_on 'python3'
   depends_on 'https://raw.github.com/wizzomafizzo/starcheat/master/mac/pyqt5.rb'
-  depends_on :hg
 
   option 'without-app', 'Build without the .app (started via starcheat terminal command)'
   option 'without-binary', 'Only builds the .app, no binary install to your prefix'
@@ -80,8 +78,8 @@ class Starcheat < Formula
       system 'tar', 'czf', 'starcheat.tar.gz', 'StarCheat.app'
       unless ENV['TRAVIS_BUILD_ID'].nil?
         # why using octokit when you habe curl and regex ;-) (creates a new release from the current commit and extracts the upload url from it)
-        `curl -H "Authorization: token #{HOMEBREW_GITHUB_API_TOKEN}" -H "Accept: application/json" -d '{"tag_name":"#{ENV['TRAVIS_COMMIT'][0..6]}","target_commitish":"#{ENV['TRAVIS_COMMIT']}","name":"starcheat (#{ENV['TRAVIS_COMMIT'][0..6]})","prerelease":true}' https://api.github.com/repos/wizzomafizzo/starcheat/releases` =~ /.*"upload_url":\s*"([\w\.\:\/]*){\?name}.*/m
-        `curl -H "Authorization: token #{HOMEBREW_GITHUB_API_TOKEN}" -H "Accept: application/json" -H "Content-Type: application/gzip" --data-binary @starcheat.tar.gz #{$1}?name=starcheat-#{ENV['TRAVIS_COMMIT'][0..6]}.tar.gz` unless $1.nil?
+        `curl -H "Authorization: token #{HOMEBREW_GITHUB_API_TOKEN}" -H "Accept: application/json" -d '{"tag_name":"#{ENV['TRAVIS_BRANCH']}","name":"starcheat #{ENV['TRAVIS_BRANCH']}"}' https://api.github.com/repos/wizzomafizzo/starcheat/releases` =~ /.*"upload_url":\s*"([\w\.\:\/]*){\?name}.*/m
+        `curl -H "Authorization: token #{HOMEBREW_GITHUB_API_TOKEN}" -H "Accept: application/json" -H "Content-Type: application/gzip" --data-binary @starcheat.tar.gz #{$1}?name=starcheat-#{ENV['TRAVIS_BRANCH']}-osx.tar.gz` unless $1.nil?
         raise "Skipping uploading build because tag is already in use" if $1.nil?
       end
     end if build.with? 'dist'


### PR DESCRIPTION
_merge me just before we change to taged/versioned releases_

With this pull request, travis will ony build releases on pushing tags matching this regex: `/^v?(\d)+(\.\d+)*/` (branches with this name would trigger a build too, but why should someone name a branch like this)
