### PR TITLE
Fix indexing mod items on windows filesystems

### DIFF
--- a/starcheat/assets.py
+++ b/starcheat/assets.py
@@ -290,7 +290,7 @@ class Items():
             return True
         elif key.endswith(".techitem"):
             return True
-        elif key.startswith("/items") and re.match(ignore_items, key) == None:
+        elif key.startswith("items", 1) and re.match(ignore_items, key) == None:
             return True
         else:
             return False


### PR DESCRIPTION
The keys are based on OS paths and it was only checking for / not / and
\.
This change skips the first character then matches items allowing for
both.
