### PR TITLE
Item Edit GUI reference bug

### DIFF
--- a/starcheat/gui/itemedit.py
+++ b/starcheat/gui/itemedit.py
@@ -11,7 +11,7 @@ Qt item edit dialog
 
 from PyQt5.QtWidgets import QDialog, QTableWidgetItem, QDialogButtonBox, QFileDialog
 from PyQt5.QtGui import QPixmap
-import json
+import json, copy
 
 import assets, qt_itemedit, qt_itemeditoptions, saves
 from gui.common import inv_icon, ItemWidget, empty_slot
@@ -79,7 +79,7 @@ class ItemEdit():
 
         self.item_browser = None
         self.remember_browser = browser_category
-        self.item = item
+        self.item = copy.deepcopy(item)
 
         if self.item["name"] != "":
             # set name text box


### PR DESCRIPTION
Fixes wizzomafizzo/starcheat#60

Line 82 assigns the reference passed into init to self.item so all
changes to self.item are passed back to the initial caller. Fixed by
doing a deepcopy.

Haven't taken a closer look to see if there is a better way to fix it so consider this a temporary fix but it might spawn a more permanent one later. 

p.s. Thanks for working on the add and remove item options, now we can play around with valid/invalid weapon options.
