### PR TITLE
Index unknown packed files better

### DIFF
--- a/starcheat/assets.py
+++ b/starcheat/assets.py
@@ -159,7 +159,7 @@ class Assets():
 
             if mod_assets == None:
                 return index
-            elif foundModInfo and not os.path.isdir(mod_assets): #TODO: make a .pak scanner function that works for vanilla and mods
+            elif foundModInfo and self.is_packed_file(mod_assets): #TODO: make a .pak scanner function that works for vanilla and mods
                 pak_path = os.path.normpath(mod_assets)
                 pak_file = open(pak_path, 'rb')
                 bf = BlockFile(pak_file)
@@ -181,8 +181,17 @@ class Assets():
                         index.append((asset_file, asset_folder))
             return index
 
+    
+    def is_packed_file(self, path):
+        """ 
+            Returns true if the asset path is a file (will be assuming from the index that it is a packed type)
+            Returns false if the asset path is a folder (legacy/non-packed mods)
+        """
+        return os.path.isfile(path)
+    
     def read(self, key, path, image=False):
-        if path.endswith(".pak") or path.endswith(".modpak"): #allows .pak and .modpak files but there could be more extensions
+        if self.is_packed_file(path): 
+            key = key.lower()
             pak_file = open(path, 'rb')
             bf = BlockFile(pak_file)
             db = AssetDatabase(bf)


### PR DESCRIPTION
Might help with wizzomafizzo/starcheat#63

.modpak files are the new recommended file extension.

http://community.playstarbound.com/index.php?threads/modding-with-pak-files.69950/

Right now having the .modinfo inside the .modpak doesn't seem to work.
http://i.imgur.com/PztM0TQ.png

Line 162 now checks if the mod_assets path was found from a modinfo file
and the path is not a directory it will treat it as a packed file.

The read function is still hardcoded to just .pak and .modpak because
there wasn't an obvious place to store if the asset is in a packed file
or not. Most likely will need a DB update to add the column if we get
more reports of different extensions.

If the read function doesn't know the packed files extension it will
throw an error like this:
2014-02-22 20:08:29,965 ERROR    Unable to read asset file
'/recipes/sword/eyesword/eyesword1.recipe' from
'E:\Games\SteamLibrary\SteamApps\common\Starbound\mods\EyeSwordBuilder\EyeSwordBuilder.modpak'
Traceback (most recent call last):
File "C:\Dev\Git\starcheat\build\assets.py", line 212, in read
asset = load_asset_file(asset_file)
File "C:\Dev\Git\starcheat\build\assets.py", line 38, in load_asset_file
with open(filename) as f:
FileNotFoundError: [Errno 2] No such file or directory:
'E:\Games\SteamLibrary\SteamApps\common\Starbound\mods\EyeSwordBuilder\EyeSwordBuilder.modpak\recipes/sword/eyesword/eyesword1.recipe'
