### PR TITLE
Fixed Control Characters in JSON

### DIFF
--- a/starcheat/assets.py
+++ b/starcheat/assets.py
@@ -26,13 +26,13 @@ ignore_items = re.compile(".*\.(png|config|frames)", re.IGNORECASE)
 def parse_json(content, key):
     if key.endswith(".grapplinghook"):
         content = content.replace("[-.", "[-0.")
-
+    decoder = json.JSONDecoder(None,None,None,None,False,None)
     # Looking for comments
     # Allows for // inside of the " " JSON data
     content = comment_re.sub(lambda m: m.group(1) or '', content)
 
     # Return json file
-    return json.loads(content)
+    return decoder.decode(content)
 
 def load_asset_file(filename):
     with open(filename) as f:


### PR DESCRIPTION
This should fix mods like Big Box of Loot http://community.playstarbound.com/index.php?resources/fireflys-big-box-of-loot-collaboration.883/

The modinfo file has an unescaped multiline string in it. Digging around and found the information below:

From: http://docs.python.org/3.3/library/json.html
If strict is False (True is the default), then control characters will
be allowed inside strings. Control characters in this context are those
with character codes in the 0-31 range, including '\t' (tab), '\n', '\r'
and '\0'.
