### PR TITLE
Catch assets without file extensions

### DIFF
--- a/starcheat/assets.py
+++ b/starcheat/assets.py
@@ -85,17 +85,19 @@ class Assets():
             yield (asset[0], asset[1])
 
             tmp_data = None
-            if asset[0].endswith(".png"):
-                tmp_data = (asset[0], asset[1], "image", "", "", "")
-            elif blueprints.is_blueprint(asset[0]):
-                tmp_data = blueprints.index_data(asset)
-            elif species.is_species(asset[0]):
-                tmp_data = species.index_data(asset)
-            elif items.is_item(asset[0]):
-                tmp_data = items.index_data(asset)
-            elif monsters.is_monster(asset[0]):
-                tmp_data = monsters.index_data(asset)
-
+            if os.path.splitext(asset[0])[1] != '':
+                if asset[0].endswith(".png"):
+                    tmp_data = (asset[0], asset[1], "image", "", "", "")
+                elif blueprints.is_blueprint(asset[0]):
+                    tmp_data = blueprints.index_data(asset)
+                elif species.is_species(asset[0]):
+                    tmp_data = species.index_data(asset)
+                elif items.is_item(asset[0]):
+                    tmp_data = items.index_data(asset)
+                elif monsters.is_monster(asset[0]):
+                    tmp_data = monsters.index_data(asset)
+            else:
+                logging.warning("Skipping invalid asset (no file extension) %s in %s" % (asset[0], asset[1]))
             if tmp_data != None:
                 c.execute(new_index_query, tmp_data)
 
@@ -282,7 +284,7 @@ class Blueprints():
     def index_data(self, asset):
         key = asset[0]
         path = asset[1]
-        name = os.path.basename(asset[0]).split(".")[0]
+        name = os.path.splitext(asset[0])[1]
         asset_type = "blueprint"
         asset_data = self.assets.read(key, path)
 
@@ -330,7 +332,7 @@ class Items():
         key = asset[0]
         path = asset[1]
         asset_type = "item"
-        category = os.path.basename(asset[0]).split(".")[1]
+        category = os.path.splitext(asset[0])[1]
         asset_data = self.assets.read(key, path)
 
         if asset_data == None: return


### PR DESCRIPTION
Try this again its way to late to be thinking obviously. Issue #63

Based on the log file we got where it would hang ~97%
At the bottom was this:
2014-02-22 05:08:41,878 DEBUG      File "build\assets.py", line 322, in
index_data
2014-02-22 05:08:41,878 DEBUG    IndexError: list index out of range

line 322 was category = os.path.basename(asset[0]).split(".")[1]

This would return index out of bounds if there wasn't a period in the
key. Changed the line to splittext which will return a 2-tuple, index 0
is the filename index 1 is the "last extension"

Added the warning about assets that don't have extensions so modders can
fix them.
