### PR TITLE
path default value

### DIFF
--- a/starcheat/assets.py
+++ b/starcheat/assets.py
@@ -169,7 +169,9 @@ class Assets():
                     modinfo = os.path.join(folder, f)
                     try:
                         modinfo_data = load_asset_file(modinfo)
-                        path = modinfo_data["path"]
+                        path = "./"
+                        if modinfo_data["path"]:
+                            path = modinfo_data["path"]
                         mod_assets = os.path.join(folder, path)
                         found_mod_info = True
                     except ValueError:


### PR DESCRIPTION
path is an optional parameter for .modinfo/.pakinfo, starbound defaults them to "./"
